### PR TITLE
refactor: unify trigger method

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip setuptools
 
-      - name: Install OmniSafe
+      - name: Install SafePO
         run: |
           python -m pip install -vvv -e '.[test]'
 

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ To train a multi-agent algorithm:
 
 ```bash
 cd safepo/multi_agent
-python macpo.py --agent-conf 4x2 --scenario Ant --experiment benchmark
+python macpo.py --task Safety2x4AntVelocity-v0 --experiment benchmark
 ```
 
 You can also train on isaac-gym based environment:
@@ -212,13 +212,6 @@ python macpo.py --task ShadowHandOver_Safe_joint --experiment benchmark
 ```
 
 **As Isaac Gym is holding in PyPI, you should install it manually, then clone [Safety-Gymnasium](https://github.com/PKU-Alignment/safety-gymnasium) instead of installing from PyPI.**
-
-**Note**: The default value for ``task`` is ``MujucoVelocity``. The default scenrio is ``Ant`` while the default agent configuration is ``2x4``. You can run other agent or scenrio by:
-
-```bash
-cd safepo/multi_agent
-python macpo.py --agent-conf 3x1 --scenario Hopper --experiment benchmark
-```
 
 ### Plot the result
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <div align="center">
 
 [![Organization](https://img.shields.io/badge/Organization-PKU--Alignment-blue)](https://github.com/PKU-Alignment)
-[![License](https://img.shields.io/github/license/PKU-Alignment/OmniSafe?label=license)](#license)
+[![License](https://img.shields.io/github/license/PKU-Alignment/Safe-Policy-Optimization?label=license)](#license)
 [![codecov](https://codecov.io/gh/PKU-Alignment/Safe-Policy-Optimization/graph/badge.svg?token=KF0UM0UNXW)](https://codecov.io/gh/PKU-Alignment/Safe-Policy-Optimization)
 [![Documentation Status](https://readthedocs.org/projects/safe-policy-optimization/badge/?version=latest)](https://safe-policy-optimization.readthedocs.io/en/latest/?badge=latest)
 

--- a/docs/source/algorithms/comparision.rst
+++ b/docs/source/algorithms/comparision.rst
@@ -29,6 +29,11 @@ they are:
 - ``SafetyWalker2dVelocity-v1``
 - ``SafetySwimmerVelocity-v1``
 
+.. warning::
+
+     It may takes some time to load the results.
+     If you can not see the results, please directly visit `wandb.ai <https://wandb.ai/pku_rl/SafePO/reports?view=table>`_.
+
 The results are shown as follows.
 
 .. tab-set::

--- a/docs/source/usage/make.rst
+++ b/docs/source/usage/make.rst
@@ -62,10 +62,10 @@ The terminal output would be like:
 .. code-block:: bash
     
     ======= commands to run:
-    running python macpo.py --agent-conf 2x4 --scenario Ant --seed 0 --write-terminal False --experiment benchmark --headless True --total-steps 10000000
-    running python mappo.py --agent-conf 2x4 --scenario Ant --seed 0 --write-terminal False --experiment benchmark --headless True --total-steps 10000000
-    running python mappolag.py --agent-conf 2x4 --scenario Ant --seed 0 --write-terminal False --experiment benchmark --headless True --total-steps 10000000
-    running python happo.py --agent-conf 2x4 --scenario Ant --seed 0 --write-terminal False --experiment benchmark --headless True --total-steps 10000000
+    running python macpo.py --task Safety2x4AntVelocity-v0 --seed 0 --write-terminal False --experiment benchmark --headless True --total-steps 10000000
+    running python mappo.py --task Safety2x4AntVelocity-v0 --seed 0 --write-terminal False --experiment benchmark --headless True --total-steps 10000000
+    running python mappolag.py --task Safety2x4AntVelocity-v0 --seed 0 --write-terminal False --experiment benchmark --headless True --total-steps 10000000
+    running python happo.py --task Safety2x4AntVelocity-v0 --seed 0 --write-terminal False --experiment benchmark --headless True --total-steps 10000000
     ...
     running python pcpo.py --task SafetyAntVelocity-v1 --seed 0 --write-terminal False --experiment benchmark --total-steps 10000000
     running python ppo_lag.py --task SafetyAntVelocity-v1 --seed 0 --write-terminal False --experiment benchmark --total-steps 10000000

--- a/docs/source/usage/train.rst
+++ b/docs/source/usage/train.rst
@@ -23,7 +23,7 @@ The multi-agent algorithms running is similar to the single-agent algorithms. Fo
 .. code-block:: bash
 
     cd safepo/multi_agent
-    python mappolag.py --scenario Ant --agent-conf 2x4 --experiment mappo_lag_exp
+    python mappolag.py --task Safety2x4AntVelocity-v0 --experiment mappo_lag_exp
 
 Then you can check the results in the ``runs/mappo_lag_exp`` folder.
 
@@ -78,10 +78,6 @@ We provide the detailed description of the command line arguments in the followi
         |                   | for testing                    |                                              |
         +-------------------+--------------------------------+----------------------------------------------+
         | --task            | The task to run                | "MujocoVelocity"                             |
-        +-------------------+--------------------------------+----------------------------------------------+
-        | --agent-conf      | The agent configuration        | "2x4"                                        |
-        +-------------------+--------------------------------+----------------------------------------------+
-        | --scenario        | The scenario                   | "Ant"                                        |
         +-------------------+--------------------------------+----------------------------------------------+
         | --experiment      | Experiment name                | "Base"                                       |
         |                   | If used with --metadata flag,  |                                              |

--- a/safepo/common/wrappers.py
+++ b/safepo/common/wrappers.py
@@ -26,7 +26,10 @@ from gymnasium.spaces import Box
 from gymnasium.wrappers.normalize import NormalizeObservation
 
 from safety_gymnasium.vector.utils.tile_images import tile_images
-from safety_gymnasium.tasks.safe_multi_agent.safe_mujoco_multi import SafeMAEnv
+try:
+    from safety_gymnasium.tasks.safe_multi_agent.safe_mujoco_multi import SafeMAEnv
+except ImportError:
+    from safety_gymnasium.tasks.safe_multi_agent.tasks.velocity.safe_mujoco_multi import SafeMAEnv
 from typing import Optional
 try :
     from safety_gymnasium.tasks.safe_isaac_gym.envs.tasks.hand_base.vec_task import VecTaskPython

--- a/safepo/multi_agent/benchmark.py
+++ b/safepo/multi_agent/benchmark.py
@@ -39,7 +39,7 @@ def parse_args():
         "--total-steps", type=int, default=10000000, help="total number of steps"
     )
     parser.add_argument(
-        "--num-envs", type=int, default=1, help="number of environments to run in parallel"
+        "--num-envs", type=int, default=10, help="number of environments to run in parallel"
     )
     args = parser.parse_args()
 

--- a/safepo/multi_agent/benchmark.py
+++ b/safepo/multi_agent/benchmark.py
@@ -38,6 +38,9 @@ def parse_args():
     parser.add_argument(
         "--total-steps", type=int, default=10000000, help="total number of steps"
     )
+    parser.add_argument(
+        "--num-envs", type=int, default=1, help="number of environments to run in parallel"
+    )
     args = parser.parse_args()
 
     return args
@@ -59,16 +62,12 @@ if __name__ == "__main__":
     for seed in range(0, args.num_seeds):
         for task in args.tasks:
             for algo in args.algo:
-                agen_conf = multi_agent_velocity_map[task]['agent_conf']
-                scenario = multi_agent_velocity_map[task]['scenario']
                 commands += [
                     " ".join(
                         [
                             f"python {algo}.py",
-                            "--agent-conf",
-                            agen_conf,
-                            "--scenario",
-                            scenario,
+                            "--task",
+                            task,
                             "--seed",
                             str(args.start_seed + 1000*seed),
                             "--write-terminal",
@@ -79,6 +78,8 @@ if __name__ == "__main__":
                             "True",
                             "--total-steps",
                             str(args.total_steps),
+                            "--num-envs",
+                            str(args.num_envs),
                         ]
                     )
                 ]

--- a/safepo/multi_agent/macpo.py
+++ b/safepo/multi_agent/macpo.py
@@ -31,7 +31,7 @@ from safepo.common.popart import PopArt
 from safepo.common.model import MultiAgentActor as Actor, MultiAgentCritic as Critic
 from safepo.common.buffer import SeparatedReplayBuffer
 from safepo.common.logger import EpochLogger
-from safepo.utils.config import multi_agent_args, parse_sim_params, set_np_formatting, set_seed
+from safepo.utils.config import multi_agent_args, parse_sim_params, set_np_formatting, set_seed, multi_agent_velocity_map, isaac_gym_map
 
 
 def check(input):
@@ -710,7 +710,6 @@ class Runner:
         one_episode_costs = torch.zeros(1, self.config["n_eval_rollout_threads"], device=self.config["device"])
 
         eval_obs, _, _ = self.eval_envs.reset()
-        #eval_obs = torch.as_tensor(eval_obs, dtype=torch.float32, device=self.config["device"])
 
         eval_rnn_states = torch.zeros(self.config["n_eval_rollout_threads"], self.num_agents, self.config["recurrent_N"], self.config["hidden_size"],
                                    device=self.config["device"])
@@ -785,7 +784,7 @@ class Runner:
 def train(args, cfg_train):
     agent_index = [[[0, 1, 2, 3, 4, 5]],
                    [[0, 1, 2, 3, 4, 5]]]
-    if args.task == "MujocoVelocity":
+    if args.task in multi_agent_velocity_map:
         env = make_ma_mujoco_env(
         scenario=args.scenario,
         agent_conf=args.agent_conf,
@@ -801,12 +800,15 @@ def train(args, cfg_train):
         seed=cfg_eval['seed'],
         cfg_train=cfg_eval,
     )
-    else: 
+    elif args.task in isaac_gym_map:
         sim_params = parse_sim_params(args, cfg_env, cfg_train)
         env = make_ma_isaac_env(args, cfg_env, cfg_train, sim_params, agent_index)
         cfg_train["n_rollout_threads"] = env.num_envs
         cfg_train["n_eval_rollout_threads"] = env.num_envs
         eval_env = env
+    else: 
+        raise NotImplementedError
+    
     torch.set_num_threads(4)
     runner = Runner(env, eval_env, cfg_train, args.model_dir)
 

--- a/safepo/multi_agent/mappo.py
+++ b/safepo/multi_agent/mappo.py
@@ -31,7 +31,7 @@ from safepo.common.popart import PopArt
 from safepo.common.model import MultiAgentActor as Actor, MultiAgentCritic as Critic
 from safepo.common.buffer import SeparatedReplayBuffer
 from safepo.common.logger import EpochLogger
-from safepo.utils.config import multi_agent_args, parse_sim_params, set_np_formatting, set_seed
+from safepo.utils.config import multi_agent_args, parse_sim_params, set_np_formatting, set_seed, multi_agent_velocity_map, isaac_gym_map
 
 
 def check(input):
@@ -463,7 +463,6 @@ class Runner:
         one_episode_costs = torch.zeros(1, self.config["n_eval_rollout_threads"], device=self.config["device"])
 
         eval_obs, _, _ = self.eval_envs.reset()
-        eval_obs = torch.as_tensor(eval_obs, dtype=torch.float32, device=self.config["device"])
 
         eval_rnn_states = torch.zeros(self.config["n_eval_rollout_threads"], self.num_agents, self.config["recurrent_N"], self.config["hidden_size"],
                                    device=self.config["device"])
@@ -488,6 +487,7 @@ class Runner:
             if self.config["env_name"] == "Safety9|8HumanoidVelocity-v0":
                 zeros = torch.zeros(eval_actions_collector[-1].shape[0], 1)
                 eval_actions_collector[-1]=torch.cat((eval_actions_collector[-1], zeros), dim=1)
+
             eval_obs, _, eval_rewards, eval_costs, eval_dones, _, _ = self.eval_envs.step(
                 eval_actions_collector
             )
@@ -531,7 +531,7 @@ class Runner:
 def train(args, cfg_train):
     agent_index = [[[0, 1, 2, 3, 4, 5]],
                    [[0, 1, 2, 3, 4, 5]]]
-    if args.task == "MujocoVelocity":
+    if args.task in multi_agent_velocity_map:
         env = make_ma_mujoco_env(
         scenario=args.scenario,
         agent_conf=args.agent_conf,
@@ -547,12 +547,15 @@ def train(args, cfg_train):
         seed=cfg_eval['seed'],
         cfg_train=cfg_eval,
     )
-    else: 
+    elif args.task in isaac_gym_map:
         sim_params = parse_sim_params(args, cfg_env, cfg_train)
         env = make_ma_isaac_env(args, cfg_env, cfg_train, sim_params, agent_index)
         cfg_train["n_rollout_threads"] = env.num_envs
         cfg_train["n_eval_rollout_threads"] = env.num_envs
         eval_env = env
+    else: 
+        raise NotImplementedError
+    
     torch.set_num_threads(4)
     runner = Runner(env, eval_env, cfg_train, args.model_dir)
 


### PR DESCRIPTION
The training script of safe multi-agent velocity used to be:
```bash
python macpo.py --agent-conf 2x4 --scenario Ant
```
This pull request change it to:
```bash
python macpo.py --task Safety2x4AntVelocity-v0
```
Documentation and README are also updated.